### PR TITLE
Fix dependencies and crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
         "copyfiles": "^1.2.0",
         "electron": "~1.8.4",
         "tslint": "^5.9.1",
-        "typescript": "^2.7.2"
+        "typescript": "^3.5.1"
     },
     "dependencies": {
-        "pixi.js": "^4.7.0",
-        "bezier-js": "^2.2.5"
+        "bezier-js": "^2.2.5",
+        "pixi.js": "^4.7.0"
     }
 }

--- a/src/model/train.ts
+++ b/src/model/train.ts
@@ -103,10 +103,13 @@ export class Train {
 
             const passiveTarget = passiveWheel.track.movePassive(
                 passiveWheel.distance, wheel.globalPosition, this.length - 2 * this.wheelOffset);
-            passiveWheel.track = passiveTarget.track;
-            passiveWheel.distance = passiveTarget.distance;
-            passiveWheel.forward = passiveTarget.forward;
-            passiveWheel.globalPosition = passiveTarget.globalPosition;
+            if (passiveTarget) {
+                passiveWheel.track = passiveTarget.track;
+                passiveWheel.distance = passiveTarget.distance;
+                passiveWheel.forward = passiveTarget.forward;
+                passiveWheel.globalPosition = passiveTarget.globalPosition;
+            }
+
             this.positionDirty = true;
         }
     }


### PR DESCRIPTION
Without the typescript update  `npm run compile-main` fails with
```
alex@foo:~/Documents/CS452/MarklinSim$ npm run compile-main

> marklinsim@0.1.0 compile-main
> tsc

node_modules/@types/node/index.d.ts:39:1 - error TS1084: Invalid 'reference' directive syntax.

39 /// <reference lib="es2017" />
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

And without the `passiveTarget` check, the program crashes frequently with:
![Screenshot from 2022-03-07 20-20-00](https://user-images.githubusercontent.com/16820327/157146753-b7a05170-042b-48da-bd48-ab87e93ba71a.png)

Thanks so much for making this!

