### PR TITLE
move to electron v31, fix bugs, app runs again

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@types/node": "^9.4.6",
         "@types/pixi.js": "^4.7.1",
         "copyfiles": "^1.2.0",
-        "electron": "~1.8.4",
+        "electron": "~34.1.0",
         "tslint": "^5.9.1",
         "typescript": "^3.5.1"
     },

--- a/src/electron_app.ts
+++ b/src/electron_app.ts
@@ -1,29 +1,38 @@
-import { app, BrowserWindow } from 'electron';
-import * as path from 'path';
-import * as url from 'url';
+import { app, BrowserWindow } from "electron";
+import * as path from "path";
+import * as url from "url";
 
 export class ElectronApp {
-    private win: BrowserWindow;
+  private win: BrowserWindow;
 
-    public start() {
-        app.on('ready', () => this.createWindow());
+  public start() {
+    app.on("ready", () => this.createWindow());
 
-        app.on('window-all-closed', () => {
-            app.quit();
-        });
-    }
+    app.on("window-all-closed", () => {
+      app.quit();
+    });
+  }
 
-    private createWindow() {
-        this.win = new BrowserWindow({width: 1000, height: 600});
+  private createWindow() {
+    this.win = new BrowserWindow({
+      width: 1000,
+      height: 600,
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false,
+      },
+    });
 
-        this.win.loadURL(url.format({
-            pathname: path.join(__dirname, 'view', 'index.html'),
-            protocol: 'file:',
-            slashes: true
-        }));
+    this.win.loadURL(
+      url.format({
+        pathname: path.join(__dirname, "view", "index.html"),
+        protocol: "file:",
+        slashes: true,
+      }),
+    );
 
-        this.win.on('closed', () => {
-            this.win = null;
-        });
-    }
+    this.win.on("closed", () => {
+      this.win = null;
+    });
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
-import * as config from './config';
-import { MarklinIO } from './marklin/marklin_io';
-import { MarklinController } from './marklin/marklin_controller';
-import { TrackDrift } from './marklin/setup/track_drift';
-import { TrackA } from './marklin/setup/track_a';
-import { ElectronApp } from './electron_app';
-import { ipcMain, Event } from 'electron';
-import { ITickPayload } from './util/tick_payload';
+import * as config from "./config";
+import { MarklinIO } from "./marklin/marklin_io";
+import { MarklinController } from "./marklin/marklin_controller";
+import { TrackDrift } from "./marklin/setup/track_drift";
+import { TrackA } from "./marklin/setup/track_a";
+import { ElectronApp } from "./electron_app";
+import { ipcMain, IpcMainEvent } from "electron";
+import { ITickPayload } from "./util/tick_payload";
 
 const io = new MarklinIO();
 io.listenTCP(config.SOCKET_PORT);
@@ -23,12 +23,12 @@ eApp.start();
 const interval = 1000 / config.TICK_RATE;
 setInterval(() => controller.tick(interval), interval);
 
-ipcMain.on('getTickDelta', (e: Event) => {
-    const payload: ITickPayload = controller.getTick(true);
-    e.returnValue = JSON.stringify(payload);
+ipcMain.on("getTickDelta", (e: IpcMainEvent) => {
+  const payload: ITickPayload = controller.getTick(true);
+  e.returnValue = JSON.stringify(payload);
 });
 
-ipcMain.on('getTickFull', (e: Event) => {
-    const payload: ITickPayload = controller.getTick(false);
-    e.returnValue = JSON.stringify(payload);
+ipcMain.on("getTickFull", (e: IpcMainEvent) => {
+  const payload: ITickPayload = controller.getTick(false);
+  e.returnValue = JSON.stringify(payload);
 });


### PR DESCRIPTION
app was not running on my local environment on asahi linux 

moved to most recent electron version, fixed the following 2 bugs


```
> marklinsim@0.1.0 compile-main
> tsc

src/main.ts:28:7 - error TS2339: Property 'returnValue' does not exist on type '{ preventDefault: () => void; readonly defaultPrevented: boolean; }'.

28     e.returnValue = JSON.stringify(payload);
         ~~~~~~~~~~~

src/main.ts:33:7 - error TS2339: Property 'returnValue' does not exist on type '{ preventDefault: () => void; readonly defaultPrevented: boolean; }'.

33     e.returnValue = JSON.stringify(payload);
         ~~~~~~~~~~~
```

```
index.html:4 Uncaught ReferenceError: require is not defined
    at index.html:4:17
```